### PR TITLE
FMT: rearranged order of setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ The main aim of developing this desktop application was to learn Java and object
 
 ## Setup Instructions
 
-1) Install [Java](https://www.oracle.com/java/technologies/downloads/).
-2) Install [MySQL Server](https://dev.mysql.com/downloads/mysql/).
-3) Install [Git](https://git-scm.com/downloads).
+1) Install [Git](https://git-scm.com/downloads).
+2) Install [Java](https://www.oracle.com/java/technologies/downloads/).
+3) Install [MySQL Server](https://dev.mysql.com/downloads/mysql/).
 4) Navigate to the directory where you want to store the repo in either Terminal, Powershell, or Command Prompt
 5) Clone Repo: `git clone https://github.com/Tony-MK/Demo-Application.git` 
 6) Enter Repo Directory: `cd Demo-Application`


### PR DESCRIPTION
Pushed the install git instruction from third to first because it is the shortest instruction and makes it look prettier and cleaner.